### PR TITLE
Allow GraphQL package to use 0.10.* releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/chadlieberman/graphql-type-long#readme",
   "dependencies": {
-    "graphql": "^0.9.1"
+    "graphql": "^0.9.1 || ^0.10.0"
   }
 }


### PR DESCRIPTION
Hi!  Thank you for putting this package together!

We would like to use it with `graphql` `0.10.5`.  I'm sure you are aware of this, but SemVer works slightly different for pre-`1.0.0` releases in that the `^` no longer allows for the upgrade of `minor` releases (which can be seen by playing around with http://jubianchi.github.io/semver-check/).

Given this, without this change we end up with two different GraphQL installations:
* `node_modules/graphql` <-- `0.10.5`
* `node_modules/graphql-type-long/node_modules/graphql` <-- `0.9.*`

This causes issues in the `instanceof` checks that are used in the [`isInputType`](http://graphql.org/graphql-js/type/#isinputtype) and [`isOutputType`](http://graphql.org/graphql-js/type/#isoutputtype) checks when using this package, because we are comparing against versions of `GraphQLScalarType` from different versions of `graphql`.

Opening this constraint up allows users of both `0.9.*` and `0.10.*` versions of `graphql` to only have a single version of this package installed.