### PR TITLE
Allow peer dependency of graphql ^0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/chadlieberman/graphql-type-long#readme",
   "peerDependencies": {
-    "graphql": "^0.9.1 || ^0.10.0 || ^0.12.0 || ^0.13.0"
+    "graphql": "^0.9.1 || ^0.10.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
   }
 }


### PR DESCRIPTION
When using graphql >=14, npm warns that this package needs a peer dependency of a lower version.
However, this works with graphql >=14, so it should be a valid peer dependency.
Tested with many 0.14 versions, most notably 0.14.6, which is the most recent as I'm writing this.